### PR TITLE
export toggle-focus

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -4,6 +4,7 @@ import SubAtom from 'sub-atom';
 import {
   enable as enableAutohide,
   disable as disableAutohide,
+  show as show,
 } from './autohide-tree-view.js';
 
 import {
@@ -41,6 +42,10 @@ export function activate() {
     },
     ['autohide-tree-view:toggle-push-editor']() {
       toggleConfig('pushEditor');
+    },
+    ['autohide-tree-view:toggle-focus']() {
+      // There's a bug for toggle, because the isVisible() always return false.
+      show();
     },
   }));
 


### PR DESCRIPTION
The original tree-view has a function: `tree-view:toggle-focus`.

The mouse hover is very good, but sometimes I don't like move mouse.

So I try to add similiar feature, but there's a bug in your codes.
The `toggle()` in `autohide-tree-view.js` doesn't work, because the `isVisible()` always return `false`.
